### PR TITLE
Adding more checks for a team permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Use the following environment variables to configure the application:
 | **GITHUB_UPLOAD_URL** | No | https://uploads.github.com/ | The GitHub upload URL for uploading files. <br> <br>It is taken into account only when the `GITHUB_BASE_URL` is also set. If only the `GITHUB_BASE_URL` is provided then this parameter defaults to the `GITHUB_BASE_URL` value. |
 | **CHECK_FAILURE_LEVEL** | No | `warning` | Defines the level on which application should treat check issue as a failure. Defaults to `warning`, which treats both `error` and `warning` as failure and exits with error code 2. Possible values are: `error` and `warning`. |
 | **OWNER_CHECKER_ORGANIZATION_NAME** | Yes | | The organization name where the repository is created. Used to check if GitHub owner is in the given organization. |
+| **CHECK_PATHS** | No | `true` |  Disable file path check. |
+| **CHECK_OWNERS** | No | `true` | Disable owners permissions check. |
+
 
 
 ![usage](./docs/assets/usage.png)

--- a/internal/check/valid_owner.go
+++ b/internal/check/valid_owner.go
@@ -122,8 +122,21 @@ func (v *ValidOwnerChecker) validateTeam(ctx context.Context, name string) *vali
 		return false
 	}
 
+	teamHasPermissions := func() bool {
+		for _, v := range allTeams {
+			if v.GetPermission() != "pull" {
+				return true
+			}
+		}
+		return false
+	}
+
 	if !teamExists() {
-		return &validateError{fmt.Sprintf("Team %q does not exits in organization %q", name, org), Warning, false}
+		return &validateError{fmt.Sprintf("Team %q does not exits in organization %q or has no permissions associated with the repository.", team, org), Warning, false}
+	}
+
+	if !teamHasPermissions() {
+		return &validateError{fmt.Sprintf("Team %q doesn't have write access to the repository.", team), Warning, false}
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -57,13 +57,13 @@ func main() {
 	codeownersEntries, err := codeowners.NewFromPath(cfg.RepositoryPath)
 	fatalOnError(err)
 
-	if cfg.CheckPaths == true {
+	if cfg.CheckPaths {
 		checks = []check.Checker{
 			check.NewFileExist(),
 		}
 	}
 
-	if cfg.CheckOwners == true {
+	if cfg.CheckOwners {
 		httpClient := http.DefaultClient
 		if cfg.Github.AccessToken != "" {
 			httpClient = oauth2.NewClient(ctx, oauth2.StaticTokenSource(

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 // Config holds the application configuration
 type Config struct {
 	RepositoryPath string
+	CheckPaths     bool `envconfig:"default=true"`
+	CheckOwners    bool `envconfig:"default=true"`
 	Github         struct {
 		AccessToken string `envconfig:"optional"`
 		BaseURL     string `envconfig:"optional"`
@@ -33,6 +35,8 @@ type Config struct {
 
 func main() {
 	var cfg Config
+	var checks []check.Checker
+	var ghClient *github.Client
 	err := envconfig.Init(&cfg)
 	fatalOnError(err)
 
@@ -42,25 +46,39 @@ func main() {
 	defer cancelFunc()
 	cancelOnInterrupt(ctx, cancelFunc)
 
-	// init GitHub client
-	httpClient := http.DefaultClient
-	if cfg.Github.AccessToken != "" {
-		httpClient = oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: cfg.Github.AccessToken},
-		))
+	// check are the both checks disabled
+	if !cfg.CheckPaths && !cfg.CheckOwners {
+		log.Error("No checks requested. Please set CHECK_PATHS or CHECK_OWNERS. Aborting...")
+		fatalOnError(err)
 	}
-
-	ghClient, err := newGithubClient(cfg, httpClient)
 	fatalOnError(err)
 
 	// init codeowners entries
 	codeownersEntries, err := codeowners.NewFromPath(cfg.RepositoryPath)
 	fatalOnError(err)
 
-	// aggregates checks
-	checks := []check.Checker{
-		check.NewFileExist(),
-		check.NewValidOwner(cfg.OwnerChecker, ghClient),
+	if cfg.CheckPaths == true {
+		checks = []check.Checker{
+			check.NewFileExist(),
+		}
+	}
+
+	if cfg.CheckOwners == true {
+		httpClient := http.DefaultClient
+		if cfg.Github.AccessToken != "" {
+			httpClient = oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+				&oauth2.Token{AccessToken: cfg.Github.AccessToken},
+			))
+		}
+
+		ghClient, err = newGithubClient(cfg, httpClient)
+		fatalOnError(err)
+
+		checks = []check.Checker{
+			check.NewFileExist(),
+			check.NewValidOwner(cfg.OwnerChecker, ghClient),
+		}
+
 	}
 
 	// run check runner


### PR DESCRIPTION
- Adding more checks for a team permissions
   According to https://github.community/t5/How-to-use-Git-and-GitHub/CODEOWNERS-works-with-users-but-not-teams/td-p/4986 a team needs write access to a repository.
-  Adding environment variables to be able to run file check and code owners permissions check separately. We have big code owners files and it takes a lot of time. Also we are hitting API rate limits.
- Fix the error message in validateTeam function
